### PR TITLE
Use .env config files, better message replies, and some bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore extensionless files
+*
+!/**/
+!*.*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -127,3 +132,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ A discord bot that counts the amount of days an user texted on a discord channel
 
 Intructions:
 
-1. Install the discord module for python
+1. Install the discord and python3-dotenv modules for python
 2. Open https://discord.com/developers/docs and create a new application
 3. Click on the bot tab and create a new bot
 4. Copy the bot's token and assign the variable TOKEN as a string
-5. Turn on the developer mode on Discord, copy the channel's ID, and insert it in line 23 as a numeric value
+4. Create a .env file at the root of this repository
+4. Copy the bot's token as `TOKEN=myBotTokenHere` in the .env file 
+5. Turn on the developer mode on Discord and copy the channel's ID as `CHANNEL_ID=myChannelIDHere` in the .env file 
 6. You are all set!!
 
 Bot commands:

--- a/main.py
+++ b/main.py
@@ -70,14 +70,13 @@ async def on_message(message):
         print(f"highest {highest_score_hash}, current {current_score_hash}")
 
         if user_message == "/current":
-            await message.channel.send(
-                f"@{user} current streak is {current_score_hash[user_id][0]} days"
+            await message.reply(
+                f"<@{message.author.id}>'s current streak is {current_score_hash[user_id][0]} days"
             )
 
         elif user_message == "/personal-best":
-            print(highest_score_hash)
-            await message.channel.send(
-                f"@{user} highest streak is {highest_score_hash[user_id][0]} days"
+            await message.reply(
+                f"<@{message.author.id}>'s highest streak is {highest_score_hash[user_id][0]} days"
             )
 
         elif user_message == "/leaderboard":
@@ -89,10 +88,10 @@ async def on_message(message):
                 score = value[0]
                 leaderboard_msg += f"{counter}. {user}: {score} days\n"
                 counter += 1
-            await message.channel.send(leaderboard_msg)
+            await message.reply(leaderboard_msg)
 
         elif user_message == "/help":
-            await message.channel.send(
+            await message.reply(
                 "/current: Check current score\n"
                 "/personal-best: Check personal highest score\n"
                 "/leaderboard: Check top 10 leaderboard\n"

--- a/main.py
+++ b/main.py
@@ -5,8 +5,12 @@
 # imports
 import discord
 from datetime import date, timedelta, datetime
+from dotenv import dotenv_values
 
-TOKEN = 'INSERT TOKEN HERE'
+config = dotenv_values(".env")
+
+TOKEN = config["TOKEN"]
+CHANNEL_ID = int(config["CHANNEL_ID"])
 client = discord.Client()
 highestScoreHash = {}
 currentScoreHash = {}
@@ -20,7 +24,7 @@ async def on_ready():
 
 @client.event
 async def on_message(message):
-    if message.channel.id == "INSERT CHANNEL ID HERE":
+    if message.channel.id == CHANNEL_ID:
         user = str(message.author)
         userID = user.split('#')[1]
         user_message = str(message.content)

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ async def on_message(message):
         elif user_message == "/personal-best":
             print(highest_score_hash)
             await message.channel.send(
-                f"@{user} highest streak is {highest_score_hash[user_id]} days"
+                f"@{user} highest streak is {highest_score_hash[user_id][0]} days"
             )
 
         elif user_message == "/leaderboard":

--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
-# File: main.py
-# Purpose: bot that keeps counts of the days that users texted in a row on a discord channel
-# Author: Charles Wu
+"""
+File: main.py
+Purpose: bot that keeps counts of the days that users texted in a row on a discord channel
+Author: Charles Wu
+"""
 
 # imports
+from datetime import date, timedelta
+
 import discord
-from datetime import date, timedelta, datetime
 from dotenv import dotenv_values
 
 config = dotenv_values(".env")
@@ -12,77 +15,94 @@ config = dotenv_values(".env")
 TOKEN = config["TOKEN"]
 CHANNEL_ID = int(config["CHANNEL_ID"])
 client = discord.Client()
-highestScoreHash = {}
-currentScoreHash = {}
+highest_score_hash = {}
+current_score_hash = {}
+
 
 @client.event
 async def on_ready():
-    '''
+    """
     Makes the bot online
-    '''
-    print('We have logged in as {0.user}'.format(client))
+    """
+    print(f"We have logged in as {client.user}")
+
 
 @client.event
 async def on_message(message):
+    """
+    Reads messages and checks for commands
+    """
     if message.channel.id == CHANNEL_ID:
         user = str(message.author)
-        userID = user.split('#')[1]
+        user_id = user.split("#")[1]
         user_message = str(message.content)
         channel = str(message.channel.name)
-        messageDay = date.today()
-        td = timedelta(1)
-        yesterdayDate = messageDay - td
-        print(f'{userID}: {user_message} ({channel}) / {messageDay}')
-        
+        message_day = date.today()
+        day_t = timedelta(1)
+        yesterday_date = message_day - day_t
+        print(f"{user_id}: {user_message} ({channel}) / {message_day}")
+
         # Do not count the messages from the bit
         if message.author == client.user:
             return
 
-        elif userID not in highestScoreHash and userID not in currentScoreHash:
-            highestScoreHash[userID] = [1, user]
-            currentScoreHash[userID] = [1, messageDay]
+        if user_id not in highest_score_hash and user_id not in current_score_hash:
+            highest_score_hash[user_id] = [1, user]
+            current_score_hash[user_id] = [1, message_day]
 
-        elif currentScoreHash[userID][1] == yesterdayDate:
-            currentScoreHash[userID][0] += 1
-            currentScoreHash[userID][1] = messageDay
-            if highestScoreHash[userID][0] <= currentScoreHash[userID][0]:
-                highestScoreHash[userID][0] = currentScoreHash[userID][0]
-                highestScoreHash[userID][1] = user
+        elif current_score_hash[user_id][1] == yesterday_date:
+            current_score_hash[user_id][0] += 1
+            current_score_hash[user_id][1] = message_day
+            if highest_score_hash[user_id][0] <= current_score_hash[user_id][0]:
+                highest_score_hash[user_id][0] = current_score_hash[user_id][0]
+                highest_score_hash[user_id][1] = user
 
-        elif currentScoreHash[userID][1] != yesterdayDate and currentScoreHash[userID][1] != date.today():
-            if highestScoreHash[userID][0] <= currentScoreHash[userID][0]:
-                highestScoreHash[userID][0] = currentScoreHash[userID][0]
-                highestScoreHash[userID][1] = user
-            currentScoreHash[userID][0] = 1
-            currentScoreHash[userID][1] = messageDay
+        elif (
+            current_score_hash[user_id][1] != yesterday_date
+            and current_score_hash[user_id][1] != date.today()
+        ):
+            if highest_score_hash[user_id][0] <= current_score_hash[user_id][0]:
+                highest_score_hash[user_id][0] = current_score_hash[user_id][0]
+                highest_score_hash[user_id][1] = user
+            current_score_hash[user_id][0] = 1
+            current_score_hash[user_id][1] = message_day
 
-        print(f'highest {highestScoreHash}, current {currentScoreHash}')
+        print(f"highest {highest_score_hash}, current {current_score_hash}")
 
-        if user_message == '/current':
-            await message.channel.send(f'@{user} current streak is {currentScoreHash[userID][0]} days')
+        if user_message == "/current":
+            await message.channel.send(
+                f"@{user} current streak is {current_score_hash[user_id][0]} days"
+            )
 
-        elif user_message == '/personal-best':
-            await message.channel.send(f'@{user} highest streak is {highestScoreHash[userID]} days')
+        elif user_message == "/personal-best":
+            print(highest_score_hash)
+            await message.channel.send(
+                f"@{user} highest streak is {highest_score_hash[user_id]} days"
+            )
 
-        elif user_message == '/leaderboard':
-            sorted(highestScoreHash, key = highestScoreHash.get, reverse=True)
+        elif user_message == "/leaderboard":
+            sorted(highest_score_hash, key=highest_score_hash.get, reverse=True)
             counter = 1
-            leaderboardMsg = ''
-            for value in highestScoreHash.values():
+            leaderboard_msg = ""
+            for value in highest_score_hash.values():
                 user = value[1]
                 score = value[0]
-                leaderboardMsg += f'{counter}. {user}: {score} days\n'
+                leaderboard_msg += f"{counter}. {user}: {score} days\n"
                 counter += 1
-            await message.channel.send(leaderboardMsg)
+            await message.channel.send(leaderboard_msg)
 
-        elif user_message == '/help':
-            await message.channel.send('/current: Check current score \n/personal-best: Check personal highest score \n/leaderboard: Check top 10 leaderboard')
+        elif user_message == "/help":
+            await message.channel.send(
+                "/current: Check current score\n"
+                "/personal-best: Check personal highest score\n"
+                "/leaderboard: Check top 10 leaderboard\n"
+            )
 
-    with open('currentStreaks', 'w') as file:
-            file.write(str(currentScoreHash))
+    with open("currentStreaks", "w", encoding="utf-8") as file:
+        file.write(str(current_score_hash))
 
-    with open('HighestStreaks', 'w') as file:
-            file.write(str(highestScoreHash))
+    with open("HighestStreaks", "w", encoding="utf-8") as file:
+        file.write(str(highest_score_hash))
 
 
 client.run(TOKEN)


### PR DESCRIPTION
Features:
 - Using .env files to read config parameters like CHANNEL_ID instead of hardcoding in main script.
 - Use message replies to message author instead of sending messages to channel

Bugfixes:
 - Message now properly @mentions the message author instead of just listing the author name
 - Message in response to `/personal-best` now correctly prints the number of days

Optimizations:
 - Linting and formatting
 - .gitignore now ignores files without extensions, such as currentStreaks